### PR TITLE
Sync GitLab main: easy-mode polish, session list cleanup, flag reminder timing, README mermaid removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,31 +115,6 @@ Mobius schedules browsers, terminals, GPU clusters, embedded boards, cloud serve
 
 Reach your resources through SSH, AIMUX, and controllable proxies:
 
-```mermaid
-flowchart TD
-  M["Mobius (XiaoMo)"]
-
-  subgraph P["Protocols"]
-    SSH["SSH / SFTP"]
-    AIMUX["AIMUX"]
-    PROXY["Controllable proxies"]
-  end
-
-  subgraph R["Resources"]
-    GPU["GPU clusters"]
-    NX["Embedded boards"]
-    NAS["NAS / object storage / cloud storage"]
-    CLOUD["Cloud servers"]
-    PC["Workstations"]
-    NET["Web / open literature"]
-  end
-
-  M --> SSH & AIMUX & PROXY
-  SSH --> GPU & NAS & CLOUD
-  AIMUX --> NX & PC
-  PROXY --> NET
-```
-
 <p align="center">
   <img src="https://github.com/user-attachments/assets/cd5ef0ba-1d38-4017-bf8a-e7b93d17fca0" alt="SSH and AIMUX access paths" width="480" />
 </p>

--- a/README.zh.md
+++ b/README.zh.md
@@ -118,31 +118,6 @@ Mobius 在同一个任务网络里调度浏览器、终端、GPU 集群、嵌入
 
 通过 SSH、AIMUX 和可控代理访问你的资源：
 
-```mermaid
-flowchart TD
-  M["Mobius（小莫）"]
-
-  subgraph P["协议"]
-    SSH["SSH / SFTP"]
-    AIMUX["AIMUX"]
-    PROXY["可控代理"]
-  end
-
-  subgraph R["资源"]
-    GPU["GPU 算力集群"]
-    NX["嵌入式开发板"]
-    NAS["NAS / 对象存储 / 云存储"]
-    CLOUD["云服务器"]
-    PC["工作站"]
-    NET["Web / 开放文献"]
-  end
-
-  M --> SSH & AIMUX & PROXY
-  SSH --> GPU & NAS & CLOUD
-  AIMUX --> NX & PC
-  PROXY --> NET
-```
-
 <p align="center">
   <img src="https://github.com/user-attachments/assets/cd5ef0ba-1d38-4017-bf8a-e7b93d17fca0" alt="SSH 与 AIMUX 接入路径" width="480" />
 </p>

--- a/mobius/backend/services/forgotten-flag-notify-timing.ts
+++ b/mobius/backend/services/forgotten-flag-notify-timing.ts
@@ -1,0 +1,75 @@
+export type ForgottenFlagMeta = {
+  runId?: string | null;
+  startedAt?: string | null;
+  content?: string | null;
+  mtimeMs?: number | null;
+};
+
+export type ForgottenFlagNotifyState = {
+  flagKey?: string;
+  flagMtimeMs?: number | null;
+  flagStartedAt?: string | null;
+  inactiveSince?: number | null;
+  lastNotifiedAt?: number | null;
+  count?: number;
+  [key: string]: unknown;
+};
+
+export function flagKeyForMeta(meta: ForgottenFlagMeta): string {
+  return meta.runId
+    || meta.startedAt
+    || (meta.content ? `content:${meta.content}` : `mtime:${meta.mtimeMs || 'unknown'}`);
+}
+
+export function isSameFlagState(
+  state: ForgottenFlagNotifyState | null | undefined,
+  meta: ForgottenFlagMeta,
+): boolean {
+  if (!state) return false;
+  const flagKey = flagKeyForMeta(meta);
+  return Boolean(
+    (state.flagKey && state.flagKey === flagKey)
+    || (!state.flagKey && meta.mtimeMs != null && state.flagMtimeMs === meta.mtimeMs),
+  );
+}
+
+export function observeInactiveFlag(
+  state: ForgottenFlagNotifyState | null | undefined,
+  meta: ForgottenFlagMeta,
+  nowMs: number,
+): { state: ForgottenFlagNotifyState; sameFlag: boolean; startedNow: boolean } {
+  const flagKey = flagKeyForMeta(meta);
+  const sameFlag = isSameFlagState(state, meta);
+  const current = sameFlag && state
+    ? state
+    : {
+        flagKey,
+        flagMtimeMs: meta.mtimeMs ?? null,
+        flagStartedAt: meta.startedAt || null,
+        lastNotifiedAt: null,
+        count: 0,
+      };
+  const existingInactiveSince = Number(current.inactiveSince);
+  if (Number.isFinite(existingInactiveSince) && existingInactiveSince > 0) {
+    return { state: current, sameFlag, startedNow: false };
+  }
+  return {
+    state: { ...current, inactiveSince: nowMs },
+    sameFlag,
+    startedNow: true,
+  };
+}
+
+export function observeWorkingFlag(
+  state: ForgottenFlagNotifyState | null | undefined,
+  meta: ForgottenFlagMeta,
+): ForgottenFlagNotifyState | null | undefined {
+  if (!state || !isSameFlagState(state, meta) || state.inactiveSince == null) return state;
+  return { ...state, inactiveSince: null };
+}
+
+export function continuousInactiveMs(state: ForgottenFlagNotifyState, nowMs: number): number {
+  const inactiveSince = Number(state.inactiveSince);
+  if (!Number.isFinite(inactiveSince) || inactiveSince <= 0) return 0;
+  return Math.max(0, nowMs - inactiveSince);
+}

--- a/mobius/backend/services/forgotten-flag-scanner.ts
+++ b/mobius/backend/services/forgotten-flag-scanner.ts
@@ -60,6 +60,12 @@ import {
   isAssistantSession,
 } from './assistant-session';
 import { markAssistantInternalNotificationPrompt } from './assistant-internal-messages';
+import {
+  continuousInactiveMs,
+  flagKeyForMeta,
+  observeInactiveFlag,
+  observeWorkingFlag,
+} from './forgotten-flag-notify-timing';
 import agents from '../agents';
 
 const SCAN_INTERVAL_MS = 60 * 1000;           // 每 60 秒一轮
@@ -71,12 +77,13 @@ const SCANNER_STARTED_AT_MS = Date.now();
 // 前端预填用同一份). 项目可在设置里用 forgotten_flag_message 覆盖.
 
 // 防刷/首次提醒等待: 同一个 flag 实例按 running.flag 内的稳定 runId/startedAt
-// 识别, 避免自动提醒本身刷新文件 mtime 后把同一个任务误判成新 flag.
-// flag 刚创建且未到 init 时也只记日志、不自动发消息.
+// 识别. 首次等待从扫描器首次观察到 agent 停工时开始, 不从 flag 创建时间开始;
+// 否则长任务一结束就会因 flag 年龄已超过 init 而被立即催促.
 
 const LOG_DIR = BACKEND_WORKER_LOG_DIR;
 const LOG_FILE = path.join(LOG_DIR, 'scan_forgotten_running_flag.log');
-// 通知去重状态 (跨后端重启保留): { [sessionId]: { flagKey, flagMtimeMs, lastNotifiedAt, count } }
+// 通知去重状态 (跨后端重启保留):
+// { [sessionId]: { flagKey, flagMtimeMs, inactiveSince, lastNotifiedAt, count } }
 const NOTIFY_STATE_FILE = path.join(LOG_DIR, 'forgotten_flag_notify_state.json');
 // Session 生命周期回调状态 (跨后端重启保留): 记录已观察到的 running/failed flag 转换.
 const LIFECYCLE_STATE_FILE = path.join(LOG_DIR, 'session_lifecycle_callback_state.json');
@@ -556,15 +563,20 @@ async function maybeNotify(f: any): Promise<string> {
   const sid = s.session_id;
   const backend = backendForSession(s);
   const policy = notifyPolicyForSession(s);
-  const prev = notifyState[sid];
-  const flagKey = fm.runId || fm.startedAt || (fm.content ? `content:${fm.content}` : `mtime:${fm.mtimeMs || 'unknown'}`);
-  const sameFlag = !!prev && (
-    (prev.flagKey && prev.flagKey === flagKey) ||
-    (!prev.flagKey && fm.mtimeMs != null && prev.flagMtimeMs === fm.mtimeMs)
-  );
+  const nowMs = Date.now();
+  const observed = observeInactiveFlag(notifyState[sid], fm, nowMs);
+  const prev = observed.state;
+  const flagKey = flagKeyForMeta(fm);
+  const sameFlag = observed.sameFlag;
   const sentCount = sameFlag && prev ? (Number(prev.count) || 0) : 0;
   const delayMinutes = notifyDelayMinutesForCount(policy, sentCount);
   const delayMs = delayMinutes * 60 * 1000;
+
+  // 持久化连续停工的起点. 即使服务重启, 首次等待也不会退回 flag 年龄口径.
+  if (observed.startedNow) {
+    notifyState[sid] = prev;
+    saveNotifyState();
+  }
 
   // 0) tmux 窗口必须仍存活才发. 发送前重新确认 (而非沿用扫描时采的旧 isAlive,
   //    避免扫描→发送之间窗口刚死的竞态). 窗口不在 → 只记日志, 绝不发送.
@@ -579,17 +591,19 @@ async function maybeNotify(f: any): Promise<string> {
     return 'notify=skip (tmux 窗口已不存在, 仅记录; 不再 spawn 新窗口/创建新 session)';
   }
 
-  // 1) 首次提醒等待: flag 太新 → 只记日志, 不发 (防误伤刚启动的新会话).
-  if (!sameFlag && fm.ageSec != null && fm.ageSec * 1000 < delayMs) {
-    return `notify=skip (flag 太新 ${fm.ageSec}s < ${formatMinutes(delayMinutes)}min 首次等待, 仅记录)`;
+  // 1) 连续停工等待: 每次 agent 从 working 转为 idle 都重新起算. 这既约束首次
+  //    提醒, 也避免 agent 响应提醒后刚结束下一轮就立刻触发后续 backoff 提醒.
+  const inactiveMs = continuousInactiveMs(prev, nowMs);
+  if (inactiveMs < delayMs) {
+    return `notify=skip (agent 连续停工 ${Math.floor(inactiveMs / 1000)}s < ${formatMinutes(delayMinutes)}min 等待, 仅记录)`;
   }
 
   // 2) Patience / 冷却: 同一 flag 实例最多提醒 patience 次, 后续按 backoff 递增等待.
   if (sameFlag && sentCount >= policy.patience) {
     return `notify=skip (同一 flag 已达到 patience=${policy.patience} 次上限, 仅记录; 不改状态/不删 flag)`;
   }
-  if (sameFlag && (Date.now() - (prev.lastNotifiedAt || 0)) < delayMs) {
-    const mins = Math.round((Date.now() - prev.lastNotifiedAt) / 60000);
+  if (sameFlag && (nowMs - (Number(prev.lastNotifiedAt) || 0)) < delayMs) {
+    const mins = Math.round((nowMs - Number(prev.lastNotifiedAt)) / 60000);
     return `notify=skip (同一 flag 已于 ${mins}min 前通知过, 未到 ${formatMinutes(delayMinutes)}min backoff 间隔, 累计 ${sentCount}/${policy.patience} 次)`;
   }
 
@@ -652,8 +666,15 @@ async function maybeNotify(f: any): Promise<string> {
   }
 
   // 7) 更新去重状态并持久化.
-  const count = (sameFlag && prev ? prev.count : 0) + 1;
-  notifyState[sid] = { flagKey, flagMtimeMs: fm.mtimeMs, flagStartedAt: fm.startedAt || null, lastNotifiedAt: Date.now(), count };
+  const count = (sameFlag ? (Number(prev.count) || 0) : 0) + 1;
+  notifyState[sid] = {
+    ...prev,
+    flagKey,
+    flagMtimeMs: fm.mtimeMs,
+    flagStartedAt: fm.startedAt || null,
+    lastNotifiedAt: Date.now(),
+    count,
+  };
   saveNotifyState();
 
   return `notify=SENT (src=${msgSrc}, init=${policy.initMinutes}min, backoff=${policy.backoff}, patience=${policy.patience}, scope=${policy.scope}, flagKey=${JSON.stringify(flagKey)}, paste-到现有TUI, 第 ${count} 次, 字数=${message.length})`;
@@ -777,11 +798,20 @@ async function scanOnce(): Promise<void> {
         try { jobAccomplished = backend.isJobGoalAccomplished(s.session_id); } catch {}
       }
 
+      const fm = readFlagMeta(flagPath);
+      if (isWorking === true) {
+        const prevState = notifyState[s.session_id];
+        const nextState = observeWorkingFlag(prevState, fm);
+        if (nextState !== prevState) {
+          notifyState[s.session_id] = nextState;
+          saveNotifyState();
+        }
+      }
+
       // 命中条件: flag 还在 但 agent 已停工. jobAccomplished 只作辅助信息写进日志,
       // 不参与判定本身, 避免 backend 实现差异影响扫描一致性.
       // 推入 findings, 后面写诊断 + 发提醒.
       if (isWorking === false) {
-        const fm = readFlagMeta(flagPath);
         findings.push({ s, flagPath, isAlive, isWorking, jobAccomplished, fm });
       }
     }

--- a/mobius/frontend/src/components/easy-jsonl/easy-jsonl.css
+++ b/mobius/frontend/src/components/easy-jsonl/easy-jsonl.css
@@ -47,7 +47,7 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   color: var(--text-primary);
-  font-size: 15px;
+  font-size: 14px;
   line-height: 1.55;
 }
 
@@ -107,7 +107,7 @@
 .easy-jsonl-response__heading svg { width: 14px; height: 14px; }
 .easy-jsonl-response__heading > svg { width: 13px; height: 13px; margin-left: auto; color: #4ade80; }
 .easy-jsonl-response__heading strong { font-size: 12px; }
-.easy-jsonl-response .jsonl-compact-md { padding: 0; border-radius: 0; background: transparent; font-size: 14px; line-height: 1.72; }
+.easy-jsonl-response .jsonl-compact-md { padding: 0; border-radius: 0; background: transparent; font-size: 13px; line-height: 1.72; }
 .easy-jsonl-response .jsonl-compact-md p { margin: .45rem 0; }
 .easy-jsonl-response .jsonl-compact-md pre { max-height: 34rem; border-radius: 12px; }
 
@@ -128,13 +128,13 @@
   .easy-jsonl-round + .easy-jsonl-round { padding-top: 24px; }
   .easy-jsonl-prompt { grid-template-columns: 28px minmax(0, 1fr); gap: 9px; padding: 11px 11px 11px 10px; border-radius: 9px; }
   .easy-jsonl-prompt__avatar { width: 28px; height: 28px; border-radius: 8px; }
-  .easy-jsonl-prompt p { font-size: 13px; line-height: 1.58; }
+  .easy-jsonl-prompt p { font-size: 12px; line-height: 1.58; }
   .easy-jsonl-rail { margin-left: 15px; padding-left: 23px; }
   .easy-jsonl-activity__node, .easy-jsonl-live > span { left: -23px; }
   .easy-jsonl-activity__copy { display: block; }
   .easy-jsonl-activity__copy small { display: block; margin-top: 2px; }
   .easy-jsonl-response { margin-left: 4px; padding-left: 39px; padding-right: 2px; }
-  .easy-jsonl-response .jsonl-compact-md { font-size: 13px; }
+  .easy-jsonl-response .jsonl-compact-md { font-size: 12px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/mobius/frontend/src/components/shell.tsx
+++ b/mobius/frontend/src/components/shell.tsx
@@ -10,7 +10,7 @@ import { AdminPanel, type AdminPanelTab } from './panels'
 import { MobiusLogo } from './mobius-logo'
 import { GuideHelpModal } from './guide-help'
 import { CustomThemePalette } from './custom-theme-palette'
-import { Bot, Check, ChevronDown, ChevronRight, CircleDot, CircleQuestionMark, FlaskConical, History, LayoutPanelTop, Menu, MessageSquare, Moon, Network, Palette, Plus, Search, Sliders, Sparkles, Sun, UserRound, WavesHorizontal, createLucideIcon } from 'lucide-react'
+import { Check, ChevronDown, ChevronRight, CircleDot, CircleQuestionMark, FlaskConical, History, LayoutPanelTop, Menu, MessageSquare, Moon, Network, Palette, Plus, Search, Sliders, Sparkles, Sun, UserRound, WavesHorizontal, createLucideIcon } from 'lucide-react'
 import { THEME_OPTIONS, getThemeOption } from '../theme'
 import { applyCustomThemeToRoot, customThemeSwatches, getBaseOption, loadActiveCustomThemeId, loadCustomThemes, saveActiveCustomThemeId, type CustomTheme } from '../services/custom-themes'
 import { pollRecursive } from '../services/polling'
@@ -705,9 +705,6 @@ function RecentSessionsPanel({
                           aria-current={active ? 'true' : undefined}
                         >
                           <span className="absolute -left-2 top-1/2 w-1.5 border-t" style={{ borderColor: 'var(--border-color)' }} aria-hidden="true" />
-                          <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--bg-card)', color: 'var(--text-secondary)' }}>
-                            {isResearch ? <Bot className="h-3 w-3" /> : <MessageSquare className="h-3 w-3" />}
-                          </span>
                           <span className="min-w-0 flex-1">
                             <span className="flex min-w-0 items-center gap-1">
                               <span className="flex-shrink-0 rounded px-1 py-0.5 text-[8px] font-medium leading-3" style={{ color: 'var(--text-secondary)', background: 'var(--bg-card)' }}>{isResearch ? '智能体' : '会话'}</span>

--- a/mobius/frontend/src/pages/EasyModePage.tsx
+++ b/mobius/frontend/src/pages/EasyModePage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import {
-  Bot,
   Check,
   CheckCircle2,
   ChevronDown,
@@ -782,9 +781,6 @@ export default function EasyModePage() {
                               title={session.name || session.session_id}
                             >
                               <span className="absolute -left-2.5 top-1/2 w-2 border-t" style={{ borderColor: 'var(--border-color)' }} aria-hidden="true" />
-                              <span className="inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--bg-card)', color: 'var(--text-secondary)' }}>
-                                {isResearch ? <Bot className="h-3.5 w-3.5" /> : <MessageSquare className="h-3.5 w-3.5" />}
-                              </span>
                               <span className="min-w-0 flex-1">
                                 <span className="flex min-w-0 items-center gap-1.5">
                                   <span className="flex-shrink-0 rounded px-1 py-0.5 text-[9px] font-medium leading-3" style={{ color: 'var(--text-secondary)', background: 'var(--bg-card)' }}>

--- a/mobius/frontend/src/pages/IssuePage.tsx
+++ b/mobius/frontend/src/pages/IssuePage.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
-import { Bot, CircleDot, ChevronDown, ChevronRight, FlaskConical, MessageSquare, MessageSquarePlus, Plus } from 'lucide-react'
+import { CircleDot, ChevronDown, ChevronRight, FlaskConical, MessageSquare, MessageSquarePlus, Plus } from 'lucide-react'
 import { useStore, api } from '../store'
 import { TopNav, timeAgo, timeAgoPrecise } from '../components/shell'
 import { ResizablePanel, useIsMobile } from '../components/resizable-panel'
@@ -607,9 +607,6 @@ export default function IssuePage() {
                               aria-current={active ? 'true' : undefined}
                             >
                               <span className="absolute -left-2 top-1/2 w-1.5 border-t" style={{ borderColor: 'var(--border-color)' }} aria-hidden="true" />
-                              <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-md" style={{ background: 'var(--bg-card)', color: 'var(--text-secondary)' }}>
-                                {isResearch ? <Bot className="h-3 w-3" /> : <MessageSquare className="h-3 w-3" />}
-                              </span>
                               <span className="min-w-0 flex-1">
                                 <span className="flex min-w-0 items-center gap-1">
                                   <span className="flex-shrink-0 rounded px-1 py-0.5 text-[8px] font-medium leading-3" style={{ color: 'var(--text-secondary)', background: 'var(--bg-card)' }}>{isResearch ? '智能体' : '会话'}</span>

--- a/mobius/package.json
+++ b/mobius/package.json
@@ -10,6 +10,7 @@
     "test:access-control": "node --require tsx/cjs tests/access-control-policy.js",
     "test:user-isolation-v3": "node --require tsx/cjs tests/user-isolation-v3.js",
     "test:assistant-running-flag": "node --require tsx/cjs tests/assistant-running-flag.js",
+    "test:forgotten-flag-notify-timing": "node --require tsx/cjs tests/forgotten-flag-notify-timing.js",
     "test:assistant-tts-cache": "node --require tsx/cjs tests/assistant-tts-cache.js",
     "test:code-server-workspace": "node --require tsx/cjs tests/code-server-workspace.js",
     "test:native-file-menu": "node --require tsx/cjs tests/native-file-menu.js",

--- a/mobius/tests/forgotten-flag-notify-timing.js
+++ b/mobius/tests/forgotten-flag-notify-timing.js
@@ -1,0 +1,49 @@
+const assert = require('assert')
+
+const {
+  continuousInactiveMs,
+  observeInactiveFlag,
+  observeWorkingFlag,
+} = require('../backend/services/forgotten-flag-notify-timing')
+
+const MINUTE = 60 * 1000
+const oldFlag = {
+  runId: 'session-1:old-start',
+  startedAt: '2026-08-18T08:25:45.041Z',
+  mtimeMs: Date.parse('2026-08-18T08:25:45.041Z'),
+}
+
+// Regression: a long-running task's old flag must not consume the post-stop grace period.
+const stoppedAt = Date.parse('2026-08-18T08:53:00.000Z')
+const firstIdle = observeInactiveFlag(null, oldFlag, stoppedAt)
+assert.strictEqual(firstIdle.startedNow, true)
+assert.strictEqual(firstIdle.state.inactiveSince, stoppedAt)
+assert.strictEqual(continuousInactiveMs(firstIdle.state, stoppedAt + MINUTE), MINUTE)
+assert.ok(
+  continuousInactiveMs(firstIdle.state, stoppedAt + MINUTE) < 10 * MINUTE,
+  'a task that stopped one minute ago must still be inside a ten-minute grace period',
+)
+
+// Repeated idle scans preserve the original transition time, including across process reloads.
+const secondIdle = observeInactiveFlag(firstIdle.state, oldFlag, stoppedAt + 2 * MINUTE)
+assert.strictEqual(secondIdle.startedNow, false)
+assert.strictEqual(secondIdle.state.inactiveSince, stoppedAt)
+
+// Once work resumes, the next idle period starts from zero even for the same stable runId.
+const working = observeWorkingFlag(secondIdle.state, oldFlag)
+assert.strictEqual(working.inactiveSince, null)
+const stoppedAgainAt = stoppedAt + 20 * MINUTE
+const thirdIdle = observeInactiveFlag(working, oldFlag, stoppedAgainAt)
+assert.strictEqual(thirdIdle.startedNow, true)
+assert.strictEqual(thirdIdle.state.inactiveSince, stoppedAgainAt)
+assert.strictEqual(continuousInactiveMs(thirdIdle.state, stoppedAgainAt + MINUTE), MINUTE)
+
+// A genuinely new flag instance gets a fresh counter and grace period.
+const newFlag = { runId: 'session-1:new-start', startedAt: '2026-08-18T09:30:00.000Z' }
+const previousNotification = { ...thirdIdle.state, count: 2, lastNotifiedAt: stoppedAgainAt }
+const newIdle = observeInactiveFlag(previousNotification, newFlag, stoppedAgainAt + 30 * MINUTE)
+assert.strictEqual(newIdle.sameFlag, false)
+assert.strictEqual(newIdle.state.count, 0)
+assert.strictEqual(newIdle.state.lastNotifiedAt, null)
+
+console.log('forgotten-flag-notify-timing: ok')


### PR DESCRIPTION
Mirrors GitLab main to GitHub:
- Reduce easy-mode session font sizes
- Remove session type icon box from recent session lists
- Fix forgotten flag reminder grace timing (+ tests)
- Remove the Connect Everything mermaid diagram from both READMEs