### PR TITLE
Add macOS one-line install video to README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ Mobius ships with built-in extensions and grows new ones from your needs — fin
 
 Full deployment guide at [Docs](https://mobius-system.github.io/mobius/en/).
 
+### Option 0: One-line install for macOS
+
+```bash
+bash <(curl -fsSL https://serve.nutshellai.cn/publish/auto/tutorial/deploy-mac-v20.sh)
+```
+
+Demo video: [Mobius one-line install on macOS](https://www.bilibili.com/video/BV1AAtT6aEoR)
+
 ### Containers (recommended)
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,6 +34,14 @@
 
 已有 Docker 环境？从下面的路径开始，启动后就能进入 Mobius 工作台。首次构建会下载镜像和依赖，耗时取决于网络与机器配置。
 
+### 方法0：macOS 本地一键安装（一行命令）
+
+```bash
+bash <(curl -fsSL https://serve.nutshellai.cn/publish/auto/tutorial/deploy-mac-v20.sh)
+```
+
+安装演示视频：[莫比乌斯 MacOS 本地一键安装](https://www.bilibili.com/video/BV1AAtT6aEoR)
+
 ### 方法1：容器（推荐，适用于 Windows / Linux / macOS）
 
 ```bash


### PR DESCRIPTION
Add a Option-0 / 方法0 one-line macOS install (deploy-mac-v20.sh) with Bilibili demo video link to both README.md and README.zh.md install sections.