### PR TITLE
Fold macOS one-line install into container section as a single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,15 +171,9 @@ Mobius ships with built-in extensions and grows new ones from your needs — fin
 
 Full deployment guide at [Docs](https://mobius-system.github.io/mobius/en/).
 
-### Option 0: One-line install for macOS
-
-```bash
-bash <(curl -fsSL https://serve.nutshellai.cn/publish/auto/tutorial/deploy-mac-v20.sh)
-```
-
-Demo video: [Mobius one-line install on macOS](https://www.bilibili.com/video/BV1AAtT6aEoR)
-
 ### Containers (recommended)
+
+> One-line install for macOS: `bash <(curl -fsSL https://serve.nutshellai.cn/publish/auto/tutorial/deploy-mac-v20.sh)` — [demo video](https://www.bilibili.com/video/BV1AAtT6aEoR)
 
 ```bash
 # 1. Clone the repo (tip: fork first, then clone — after self-evolution you can commit directly to your own repo)

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,15 +34,9 @@
 
 已有 Docker 环境？从下面的路径开始，启动后就能进入 Mobius 工作台。首次构建会下载镜像和依赖，耗时取决于网络与机器配置。
 
-### 方法0：macOS 本地一键安装（一行命令）
-
-```bash
-bash <(curl -fsSL https://serve.nutshellai.cn/publish/auto/tutorial/deploy-mac-v20.sh)
-```
-
-安装演示视频：[莫比乌斯 MacOS 本地一键安装](https://www.bilibili.com/video/BV1AAtT6aEoR)
-
 ### 方法1：容器（推荐，适用于 Windows / Linux / macOS）
+
+> macOS 一键安装（一行命令）：`bash <(curl -fsSL https://serve.nutshellai.cn/publish/auto/tutorial/deploy-mac-v20.sh)`，[演示视频](https://www.bilibili.com/video/BV1AAtT6aEoR)
 
 ```bash
 # 1. 克隆仓库（建议先 fork，再 clone；这样自进化后可直接提交到自己的仓库）


### PR DESCRIPTION
Follow-up to #12: the deploy-mac-v20.sh script wraps the container deployment, so present it as one line inside the Containers section instead of a separate Option 0.